### PR TITLE
Add intro end / credit end markers in EDL / inline chapters

### DIFF
--- a/bw_plex/edl.py
+++ b/bw_plex/edl.py
@@ -18,13 +18,13 @@ TYPES.update(dict((v, k) for (k, v) in TYPES.items()))
 def db_to_edl(item, type=3):
     elds = {}
 
-    # Add credits
     if (item.correct_theme_start and
         item.correct_theme_start != -1 and
         item.correct_theme_end and
         item.correct_theme_end != -1):
 
         elds["manual intro"] = [item.correct_theme_start, item.correct_theme_end, TYPES[type]]
+        elds["manual intro end"] = [item.correct_theme_end, item.correct_theme_end, 2]
 
     elif (item.theme_start and
           item.theme_start != -1 and
@@ -32,13 +32,14 @@ def db_to_edl(item, type=3):
           item.theme_end != -1):
 
         elds["intro"] = [item.theme_start, item.theme_end, TYPES[type]]
-
+        elds["intro end"] = [item.theme_end, item.theme_end, 2]
     if (item.credits_start and
         item.credits_start != -1 and
         item.credits_end and
         item.credits_end != -1):
 
         elds["credits"] = [item.credits_start, item.credits_end, TYPES[type]]
+        elds["credits end"] = [item.credits_end, item.credits_end, 2]
 
     return elds
 
@@ -123,5 +124,3 @@ def write_chapters_to_file(path, input_edl=None, replace=True, cleanup=True):
     LOG.debug('writing chapters to file using command %s', ' '.join(cmd))
 
     return path
-
-


### PR DESCRIPTION
This change adds a config setting to bw_plex that makes it write a chapter marker (type "scene marker") for the "intro end" and "credits end" timestamp.

This is specifically for plex folks (like me) who don't like it when bw_plex skips for them, but want to manually skip to the beginning/end of the intro: Plex doesn't support "duration" type markers like "commercial break", so the only thing that the interface showed before was a chapter "Intro" at the very beginning. 

Now, it also shows an "intro end" marker, which makes me much happier.

I hope you will consider this for inclusion.