### PR TITLE
Shrink docker image & correct CMD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.whl
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,24 @@
+FROM ubuntu:18.04 AS builder
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV LC_ALL C.UTF-8
+ENV lang C.UTF-8
+RUN apt-get update && apt-get -y install \
+  git-core swig libpulse-dev libasound2-dev ffmpeg tesseract-ocr python3-pip pandoc python3.6-tk \
+  python3-setuptools python3-venv && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* && \
+  python3 -m venv /app/bw_plex
+
+ENV PATH="/app/bw_plex/bin:$PATH"
+WORKDIR /src
+
+# Python requirements from pip
+RUN pip3 --no-cache-dir install pytest pytest-cov pytest-mock pytest_click pypandoc codecov \
+  opencv-contrib-python-headless SpeechRecognition pocketsphinx pytesseract
+
+ADD . /src
+RUN pip3 --no-cache-dir wheel -e . && pip3 --no-cache-dir install bw_plex*.whl
+
 FROM ubuntu:18.04
-
-# This images is much bigger then i want, ill try to reduce it
-# but im such a docker noob, send a PR if you know how to fix it.
-
 LABEL maintainer="hellowlol1@gmail.com"
 
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -11,22 +27,12 @@ ENV lang C.UTF-8
 
 # Package requirements
 RUN apt-get update && apt-get -y install \
-  git swig libpulse-dev libasound2-dev ffmpeg tesseract-ocr python3-pip pandoc python3.6-tk \
-  python3-setuptools && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* && \
-  mkdir -p /app/bw_plex
+  libpulse0 libasound2 ffmpeg tesseract-ocr python3-pip pandoc python3.6-tk \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-# Python requirements from pip
-RUN pip3 install pytest pytest-cov pytest-mock pytest_click pypandoc codecov \
-  opencv-contrib-python-headless SpeechRecognition pocketsphinx pytesseract
-
-RUN git clone --depth=1 https://github.com/Hellowlol/bw_plex.git /app/bw_plex
-#&& rm -rf /app/bw_plex/.git
-
-# This is needed for the the manual install of bw_plex
-WORKDIR /app/bw_plex
-
-RUN pip3 install -e .
+COPY --from=builder /app/bw_plex /app/bw_plex
+ENV PATH="/app/bw_plex/bin:$PATH"
 
 # COPY root/ /
 VOLUME /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PATH="/app/bw_plex/bin:$PATH"
 VOLUME /config
 
 
-CMD ["sh", "-c", "bw_plex --url ${url} -t ${token} -df /config watch"]
+CMD ["bw_plex", "-df", "/config", "watch"]
 
 
 # To build (Docker image):


### PR DESCRIPTION
This PR makes a bunch of adjustments to the docker build process that result in a smaller image: From what I can tell, it's about 400MB thinner:

```
$ docker images | grep bw_plex
hellowlol/bw_plex    latest              4fd99864a050        6 weeks ago         1.87GB
hellowlol/bw_plex    antifuchs           a33789f9b5fb        17 minutes ago      1.4GB
```

This PR also adjusts the `CMD` in use to launch bw_plex in the container, as the previous iteration relied on env variables `url` and `token` being set, which I believe most people will want to set in the `/config` ini file instead.

# How does this work?

Via https://pythonspeed.com/articles/multi-stage-docker-python/, the technique for getting the multi-stage build to improve the image size is this:

* Make a container that contains all the build dependencies
* Put the current git checkout in there (this is changed from what's on master - doing it via `ADD` allows developers to try their changes in isolation)
* Make a venv containing all the dependencies we know about
* build a wheel from the bw_plex checkout & install it in the venv

Then, we make a container containing only the runtime libraries needed to run bw_plex (rather than the `-dev` ones), and copy the venv over. Voila, lots fewer build steps with less caching in between them.

# This could still be better

We could still save a bunch more space by not installing those test/dev-looking dependencies, like pytest below and leaving out pandoc. I'll leave that to you to figure out whether that's desired (: